### PR TITLE
select all chars when focus on `commandEntryView`

### DIFF
--- a/lib/run-command-view.coffee
+++ b/lib/run-command-view.coffee
@@ -65,6 +65,8 @@ class RunCommandView extends View
     atom.workspaceView.append this
     @storeFocusedElement()
     @commandEntryView.focus()
+    editor = @commandEntryView.editor
+    editor.setSelectedBufferRange editor.getBuffer().getRange()
 
   destroy: =>
     @cancel()


### PR DESCRIPTION
Hello @kylewlacy
I added a feature to select all characters when focus on the commandEntryView.
![2014-07-23 17 20 16](https://cloud.githubusercontent.com/assets/1680868/3671015/da016950-124a-11e4-8dfd-5beccdffe7a6.png)
